### PR TITLE
Add help section to main page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -154,7 +154,7 @@ export default function Home() {
         </p>
         <p>
           Reading isn't the focus, but you can view everything you've written by
-          visiting <a href="/all">/all</a>.
+          visiting https://lekh.space/username/all.
         </p>
         <p>
           Have feedback or found a bug? Raise an issue at{' '}

--- a/pages/index.js
+++ b/pages/index.js
@@ -146,6 +146,22 @@ export default function Home() {
         </div>
       )}
 
+      <section className="help">
+        <h2>What is this?</h2>
+        <p>
+          This is a place to write without interruptions. There is no
+          authentication—just open your link anywhere and start writing.
+        </p>
+        <p>
+          Reading isn't the focus, but you can view everything you've written by
+          visiting <a href="/all">/all</a>.
+        </p>
+        <p>
+          Have feedback or found a bug? Raise an issue at{' '}
+          <a href="https://github.com/swappysh/lekh">github.com/swappysh/lekh</a>.
+        </p>
+      </section>
+
       <style jsx global>{`
         body {
           background: #FAFAF7;
@@ -270,6 +286,18 @@ export default function Home() {
           background: #f8d7da;
           border: 1px solid #f5c6cb;
           color: #721c24;
+        }
+
+        .help {
+          margin-top: 40px;
+        }
+
+        .help h2 {
+          margin-bottom: 10px;
+        }
+
+        .help p {
+          margin: 0 0 10px 0;
         }
 
         @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- add help section on main page explaining purpose, no auth, /all for reading, and link to GitHub for issues
- style help section for spacing

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --include=dev` *(fails: ENOTEMPTY while renaming cliui directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aada24fac0832db0831ce67f993ac1