### PR TITLE
refactor: extract colors and font to CSS custom properties

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,59 @@
+# Design Context
+
+## Users
+Solo writers who want an encrypted, distraction-free journal. Not technical power users, not teams — people who want a quiet, private place to write. They reach for Lekh when they want to think without being watched. Privacy and simplicity are non-negotiable; clever features are suspicious.
+
+## Brand Personality
+**Voice**: Direct, minimal, honest — but warm, not cold
+**Tone**: Like a good notebook: unpretentious, reliable, slightly worn-in
+**3-word personality**: Quiet, private, trustworthy
+**Emotional goals**: Calm clarity, a sense of safety, zero friction — a writing nook, not a terminal
+
+## Aesthetic Direction
+Minimal but human — not brutalist-cold, not warm-decorative. The reference point is a well-made notebook or a text editor in focus mode: nothing distracting, but not hostile either. Typography-first, system fonts, subtle warmth in the color palette.
+
+**Visual principles:**
+- Monospace typography (SF Mono/Menlo or system monospace) — keeps the focused, writer feel
+- Light (#111111 on #FAFAF7) and Dark (#EDEDED on #0B0B0C) modes equally important
+- Slightly warmer than pure terminal: small amounts of off-white/warm-gray rather than harsh neutral
+- Zero decorative elements — no icons, gradients, heavy shadows
+- Borders minimal: 1px, subtle, only where necessary
+- Maximum content width: 600px (70-character monospace line)
+- Padding: 20px base, consistent throughout
+- Full-bleed editor height (min 100vh)
+- Touch targets: 44px minimum — mobile-first from here on
+
+**References:**
+- A worn notebook — tactile, trusted, nothing extra
+- Markdown editors in focus mode (Typora, iA Writer)
+- write.as — minimal writing interface
+- Bear app — monospace with just enough warmth
+
+**Anti-references:**
+- Cold terminal apps (iTerm2, Hyper) — too developer-y for the actual audience
+- Medium editor — too many features
+- Notion — visual complexity
+- Modern web design with cards/shadows/gradients
+
+## Design Principles
+1. **Form follows function**: Every pixel serves writing. Zero decoration.
+2. **Typography is the interface**: Monospace, proper line height/spacing, nothing else needed.
+3. **Quiet, not cold**: Minimal doesn't mean harsh. Small warmth choices (off-white bg, slightly rounded 2px) welcome writers without betraying the philosophy.
+4. **Respect the writer's focus**: Minimal cognitive load, maximum text area, auto-save (no buttons).
+5. **Light + Dark equally**: Both themes fully supported, no compromise.
+6. **Trust through simplicity**: Minimal modals only for critical actions (password, confirmation).
+7. **Mobile-first**: Touch targets, thumb-reachable actions, readable at 16px+ on small screens.
+
+## Upcoming Surface Areas (design implications)
+- **Mobile-first focus**: All new work assumes touch-first. Thumb zones matter. No hover-only affordances.
+- **Richer editor features**: If/when markdown preview or formatting lands, it must not break the quiet feel — progressive disclosure, never visible by default.
+- **Onboarding / marketing**: Landing page and sign-up flows should convert writers, not developers. Copy and design should feel human, not technical.
+
+## Implementation Notes
+- Use CSS Grid or Flexbox; avoid component-heavy solutions
+- CSS-in-JS acceptable but keep inline (no external stylesheets, per Lekh philosophy)
+- Responsive: adapt layout, don't hide features on mobile
+- No animations except cursor blink and essential feedback (no transitions > 200ms)
+- Focus states visible but minimal — border color shift, no outline ring
+- All form inputs: 1px solid border, 4px border-radius max, no heavy shadows
+- Touch targets: 44px minimum height on all interactive elements

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -195,7 +195,7 @@ describe('Home Page', () => {
     await user.click(submitButton)
     
     await waitFor(() => {
-      expect(screen.getByText('Error: Database error')).toBeInTheDocument()
+      expect(screen.getByText('Error: Unable to create your space. Please try again.')).toBeInTheDocument()
     })
   })
 

--- a/components/CollaborativeEditor.js
+++ b/components/CollaborativeEditor.js
@@ -131,7 +131,7 @@ const CollaborativeEditor = forwardRef(function CollaborativeEditor({
           padding: 10px;
           font-size: 18px;
           line-height: 1.6;
-          font-family: monospace;
+          font-family: var(--font-mono);
           border: none;
           outline: none;
           resize: none;
@@ -150,7 +150,7 @@ const CollaborativeEditor = forwardRef(function CollaborativeEditor({
           padding: 8px 12px;
           border-radius: 16px;
           font-size: 12px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           z-index: 100;
         }
 
@@ -162,7 +162,7 @@ const CollaborativeEditor = forwardRef(function CollaborativeEditor({
         @media (prefers-color-scheme: dark) {
           .active-editors-indicator {
             background: rgba(255, 255, 255, 0.1);
-            color: #EDEDED;
+            color: var(--color-text);
           }
         }
 

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -27,7 +27,7 @@ const Editor = forwardRef(function Editor({ content, setContent }, ref) {
           padding: 10px;
           font-size: 18px;
           line-height: 1.6;
-          font-family: monospace;
+          font-family: var(--font-mono);
           border: none;
           outline: none;
           resize: none;

--- a/components/PasswordModal.js
+++ b/components/PasswordModal.js
@@ -66,13 +66,13 @@ export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Ente
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%);
-          background: #FAFAF7;
+          background: var(--color-bg);
           padding: 30px;
           border-radius: 8px;
           box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
           z-index: 1001;
           min-width: 400px;
-          font-family: monospace;
+          font-family: var(--font-mono);
         }
         .modal-content h2 {
           margin: 0 0 20px 0;
@@ -83,14 +83,14 @@ export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Ente
           padding: 12px;
           border: 1px solid #ddd;
           border-radius: 4px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           margin-bottom: 20px;
           box-sizing: border-box;
         }
         .password-input:focus {
           outline: none;
-          border-color: #0B57D0;
+          border-color: var(--color-accent);
         }
         .modal-buttons {
           display: flex;
@@ -101,12 +101,12 @@ export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Ente
           padding: 10px 20px;
           border: none;
           border-radius: 4px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           cursor: pointer;
           font-size: 14px;
         }
         .modal-buttons button[type="submit"] {
-          background: #0B57D0;
+          background: var(--color-accent);
           color: white;
         }
         .modal-buttons button[type="submit"]:hover:not(:disabled) {
@@ -126,26 +126,26 @@ export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Ente
         @media (prefers-color-scheme: dark) {
           .modal-content {
             background: #1a1a1a;
-            color: #EDEDED;
+            color: var(--color-text);
           }
           .password-input {
             background: #2a2a2a;
             border-color: #444;
-            color: #EDEDED;
+            color: var(--color-text);
           }
           .password-input:focus {
-            border-color: #8AB4F8;
+            border-color: var(--color-accent);
           }
           .modal-buttons button[type="submit"] {
-            background: #8AB4F8;
-            color: #0B0B0C;
+            background: var(--color-accent);
+            color: var(--color-bg);
           }
           .modal-buttons button[type="submit"]:hover:not(:disabled) {
             background: #A8C7FA;
           }
           .modal-buttons button[type="button"] {
             background: #333;
-            color: #EDEDED;
+            color: var(--color-text);
           }
           .modal-buttons button[type="button"]:hover {
             background: #444;

--- a/components/ShortcutsModal.js
+++ b/components/ShortcutsModal.js
@@ -33,18 +33,18 @@ export const ShortcutsModal = ({ isOpen, onClose, shortcuts, username }) => {
           <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
             {username && (
               <li style={{ marginBottom: '8px' }}>
-                <a 
+                <a
                   href={`/${username}/all`}
-                  style={{ color: '#8AB4F8', textDecoration: 'none' }}
+                  style={{ color: 'var(--color-accent)', textDecoration: 'none' }}
                 >
                   View all entries →
                 </a>
               </li>
             )}
             <li>
-              <a 
+              <a
                 href="/"
-                style={{ color: '#8AB4F8', textDecoration: 'none' }}
+                style={{ color: 'var(--color-accent)', textDecoration: 'none' }}
               >
                 Back to home
               </a>

--- a/pages/[username].js
+++ b/pages/[username].js
@@ -448,7 +448,7 @@ export default function UserPage() {
         <style jsx>{`
           .container {
             padding: 20px;
-            font-family: monospace;
+            font-family: var(--font-mono);
             width: 70vw;
             margin: 0 auto;
           }
@@ -469,19 +469,19 @@ export default function UserPage() {
         <p><a href="/">Create a new user URL</a></p>
         <style jsx global>{`
           body {
-            background: #FAFAF7;
-            color: #111111;
+            background: var(--color-bg);
+            color: var(--color-text);
             font-size: 18px;
             line-height: 1.6;
           }
           @media (prefers-color-scheme: dark) {
             body {
-              background: #0B0B0C;
-              color: #EDEDED;
+              background: var(--color-bg);
+              color: var(--color-text);
             }
           }
           a {
-            color: #0B57D0;
+            color: var(--color-accent);
             text-decoration: underline;
           }
           a:visited {
@@ -489,7 +489,7 @@ export default function UserPage() {
           }
           @media (prefers-color-scheme: dark) {
             a {
-              color: #8AB4F8;
+              color: var(--color-accent);
             }
             a:visited {
               color: #B39DDB;
@@ -499,7 +499,7 @@ export default function UserPage() {
         <style jsx>{`
           .container {
             padding: 20px;
-            font-family: monospace;
+            font-family: var(--font-mono);
             width: 70vw;
             margin: 0 auto;
           }
@@ -559,19 +559,19 @@ export default function UserPage() {
       </button>
       <style jsx global>{`
         body {
-          background: #FAFAF7;
-          color: #111111;
+          background: var(--color-bg);
+          color: var(--color-text);
           font-size: 18px;
           line-height: 1.6;
         }
         @media (prefers-color-scheme: dark) {
           body {
-            background: #0B0B0C;
-            color: #EDEDED;
+            background: var(--color-bg);
+            color: var(--color-text);
           }
         }
         a {
-          color: #0B57D0;
+          color: var(--color-accent);
           text-decoration: underline;
         }
         a:visited {
@@ -579,7 +579,7 @@ export default function UserPage() {
         }
         @media (prefers-color-scheme: dark) {
           a {
-            color: #8AB4F8;
+            color: var(--color-accent);
           }
           a:visited {
             color: #B39DDB;
@@ -589,7 +589,7 @@ export default function UserPage() {
       <style jsx>{`
         .container {
           padding: 20px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           width: 70vw;
           margin: 0 auto;
         }
@@ -661,7 +661,7 @@ export default function UserPage() {
           width: 40px;
           height: 40px;
           border-radius: 50%;
-          background: #0B57D0;
+          background: var(--color-accent);
           color: white;
           border: none;
           font-size: 18px;
@@ -679,8 +679,8 @@ export default function UserPage() {
         }
         @media (prefers-color-scheme: dark) {
           .help-button {
-            background: #8AB4F8;
-            color: #0B0B0C;
+            background: var(--color-accent);
+            color: var(--color-bg);
           }
           .help-button:hover {
             background: #A8C7FA;

--- a/pages/[username]/all.js
+++ b/pages/[username]/all.js
@@ -132,7 +132,7 @@ export default function AllEntriesPage() {
         <style jsx>{`
           .container {
             padding: 20px;
-            font-family: monospace;
+            font-family: var(--font-mono);
             width: 70vw;
             margin: 0 auto;
           }
@@ -153,19 +153,19 @@ export default function AllEntriesPage() {
         <p><a href="/">Create a new user URL</a></p>
         <style jsx global>{`
           body {
-            background: #FAFAF7;
-            color: #111111;
+            background: var(--color-bg);
+            color: var(--color-text);
             font-size: 18px;
             line-height: 1.6;
           }
           @media (prefers-color-scheme: dark) {
             body {
-              background: #0B0B0C;
-              color: #EDEDED;
+              background: var(--color-bg);
+              color: var(--color-text);
             }
           }
           a {
-            color: #0B57D0;
+            color: var(--color-accent);
             text-decoration: underline;
           }
           a:visited {
@@ -173,7 +173,7 @@ export default function AllEntriesPage() {
           }
           @media (prefers-color-scheme: dark) {
             a {
-              color: #8AB4F8;
+              color: var(--color-accent);
             }
             a:visited {
               color: #B39DDB;
@@ -183,7 +183,7 @@ export default function AllEntriesPage() {
         <style jsx>{`
           .container {
             padding: 20px;
-            font-family: monospace;
+            font-family: var(--font-mono);
             width: 70vw;
             margin: 0 auto;
           }
@@ -250,19 +250,19 @@ export default function AllEntriesPage() {
 
       <style jsx global>{`
         body {
-          background: #FAFAF7;
-          color: #111111;
+          background: var(--color-bg);
+          color: var(--color-text);
           font-size: 18px;
           line-height: 1.6;
         }
         @media (prefers-color-scheme: dark) {
           body {
-            background: #0B0B0C;
-            color: #EDEDED;
+            background: var(--color-bg);
+            color: var(--color-text);
           }
         }
         a {
-          color: #0B57D0;
+          color: var(--color-accent);
           text-decoration: underline;
         }
         a:visited {
@@ -270,7 +270,7 @@ export default function AllEntriesPage() {
         }
         @media (prefers-color-scheme: dark) {
           a {
-            color: #8AB4F8;
+            color: var(--color-accent);
           }
           a:visited {
             color: #B39DDB;
@@ -281,7 +281,7 @@ export default function AllEntriesPage() {
       <style jsx>{`
         .container {
           padding: 40px 20px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           max-width: 800px;
           margin: 0 auto;
         }
@@ -291,7 +291,7 @@ export default function AllEntriesPage() {
           color: #666;
         }
         .header-username {
-          color: #111111;
+          color: var(--color-text);
           font-weight: bold;
         }
         .header-separator {
@@ -308,7 +308,7 @@ export default function AllEntriesPage() {
         .prompt-title {
           font-size: 18px;
           margin-bottom: 30px;
-          color: #111111;
+          color: var(--color-text);
         }
         .prompt-group {
           margin-bottom: 20px;
@@ -324,23 +324,23 @@ export default function AllEntriesPage() {
           padding: 12px;
           border: 1px solid #ccc;
           border-radius: 4px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           box-sizing: border-box;
         }
         .prompt-group input:focus {
           outline: none;
-          border-color: #0B57D0;
+          border-color: var(--color-accent);
           box-shadow: 0 0 0 2px rgba(11, 87, 208, 0.1);
         }
         .unlock-button {
           width: 100%;
           padding: 12px 24px;
-          background: #111111;
+          background: var(--color-text);
           color: white;
           border: none;
           border-radius: 4px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           cursor: pointer;
           margin-bottom: 20px;
@@ -412,15 +412,15 @@ export default function AllEntriesPage() {
             color: white;
           }
           .prompt-group input:focus {
-            border-color: #8AB4F8;
+            border-color: var(--color-accent);
             box-shadow: 0 0 0 2px rgba(138, 180, 248, 0.1);
           }
           .unlock-button {
             background: white;
-            color: #0B0B0C;
+            color: var(--color-bg);
           }
           .unlock-button:hover {
-            background: #EDEDED;
+            background: var(--color-text);
           }
           .warning-text {
             color: #ff6b6b;

--- a/pages/demo.js
+++ b/pages/demo.js
@@ -88,22 +88,22 @@ export default function DemoPage() {
 
       <style jsx global>{`
         body {
-          background: #FAFAF7;
-          color: #111111;
+          background: var(--color-bg);
+          color: var(--color-text);
           font-size: 18px;
           line-height: 1.6;
         }
         @media (prefers-color-scheme: dark) {
           body {
-            background: #0B0B0C;
-            color: #EDEDED;
+            background: var(--color-bg);
+            color: var(--color-text);
           }
         }
       `}</style>
       <style jsx>{`
         .page-container {
           padding: 20px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           max-width: 800px;
           margin: 0 auto;
         }
@@ -141,12 +141,12 @@ export default function DemoPage() {
 
         .create-account-link {
           padding: 10px 20px;
-          background: #0B57D0;
+          background: var(--color-accent);
           color: white;
           border: none;
           border-radius: 4px;
           cursor: pointer;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 14px;
           font-weight: bold;
           transition: all 0.2s;
@@ -168,12 +168,12 @@ export default function DemoPage() {
         @media (prefers-color-scheme: dark) {
           .demo-badge {
             background: #ffd93d;
-            color: #0B0B0C;
+            color: var(--color-bg);
           }
 
           .create-account-link {
-            background: #8AB4F8;
-            color: #0B0B0C;
+            background: var(--color-accent);
+            color: var(--color-bg);
           }
 
           .create-account-link:hover {

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,7 +66,7 @@ export default function Home() {
   const handleSubmit = async (e) => {
     e.preventDefault()
     const isPublic = showPublicFlow
-    
+
     if (!username.trim() || (!isPublic && !password.trim()) || !isAvailable) return
 
     const passwordStrength = getPasswordStrength(password)
@@ -80,7 +80,7 @@ export default function Home() {
 
     try {
       const saltBytes = crypto.getRandomValues(new Uint8Array(16))
-      
+
       const effectivePassword = isPublic ? username.trim() : password
       const { publicKey, encryptedPrivateKey, salt } = await PublicKeyEncryption.generateAuthorKeys(
         effectivePassword,
@@ -104,7 +104,18 @@ export default function Home() {
       const payload = await response.json()
 
       if (!response.ok) {
-        setMessage(`Error: ${payload?.error || 'Failed to create URL'}`)
+        setIsSubmitting(false)
+        const errorMap = {
+          'Username already taken': 'This username is taken. Try another one.',
+          'Invalid username': 'Username can only contain letters, numbers, hyphens, and underscores.',
+          'Failed to verify username availability': 'Unable to check availability. Please try again.',
+          'Missing required fields': 'Something went wrong. Please try again.',
+          'Invalid isPublic value': 'Something went wrong. Please try again.',
+          'Failed to create user': 'Unable to create your space. Please try again.',
+          'Internal server error': 'Our server had an issue. Please try again in a moment.',
+        }
+        const friendlyError = errorMap[payload?.error] || 'Unable to create your space. Please try again.'
+        setMessage(`Error: ${friendlyError}`)
       } else {
         const createdUsername = payload?.username || username.trim()
         setMessage(`your space is ready → lekh.space/${createdUsername}`)
@@ -119,10 +130,9 @@ export default function Home() {
         setAcknowledgedRisk(false)
       }
     } catch (err) {
-      setMessage('Error creating URL: ' + err.message)
+      setIsSubmitting(false)
+      setMessage('Error: Unable to reach the server. Please check your connection and try again.')
     }
-
-    setIsSubmitting(false)
   }
 
   const generateRandomUsername = async () => {
@@ -188,7 +198,10 @@ export default function Home() {
               <input
                 type="text"
                 value={username}
-                onChange={(e) => setUsername(e.target.value)}
+                onChange={(e) => {
+                  setUsername(e.target.value)
+                  if (message.startsWith('Error')) setMessage('')
+                }}
                 placeholder="[username]"
                 pattern="[a-zA-Z0-9_\-]+"
                 title="Only letters, numbers, hyphens, and underscores allowed"
@@ -218,6 +231,7 @@ export default function Home() {
                 onChange={(e) => {
                   setPassword(e.target.value)
                   setAcknowledgedRisk(false) // Reset when password changes
+                  if (message.startsWith('Error')) setMessage('')
                 }}
                 placeholder="[••••••••]"
                 required
@@ -313,7 +327,10 @@ export default function Home() {
                 <input
                   type="text"
                   value={username}
-                  onChange={(e) => setUsername(e.target.value)}
+                  onChange={(e) => {
+                    setUsername(e.target.value)
+                    if (message.startsWith('Error')) setMessage('')
+                  }}
                   placeholder="your-name"
                   pattern="[a-zA-Z0-9_\-]+"
                   title="Only letters, numbers, hyphens, and underscores allowed"

--- a/pages/index.js
+++ b/pages/index.js
@@ -395,19 +395,19 @@ export default function Home() {
 
       <style jsx global>{`
         body {
-          background: #FAFAF7;
-          color: #111111;
+          background: var(--color-bg);
+          color: var(--color-text);
           font-size: 18px;
           line-height: 1.6;
         }
         @media (prefers-color-scheme: dark) {
           body {
-            background: #0B0B0C;
-            color: #EDEDED;
+            background: var(--color-bg);
+            color: var(--color-text);
           }
         }
         a {
-          color: #0B57D0;
+          color: var(--color-accent);
           text-decoration: underline;
         }
         a:visited {
@@ -415,7 +415,7 @@ export default function Home() {
         }
         @media (prefers-color-scheme: dark) {
           a {
-            color: #8AB4F8;
+            color: var(--color-accent);
           }
           a:visited {
             color: #B39DDB;
@@ -425,7 +425,7 @@ export default function Home() {
       <style jsx>{`
         .container {
           padding: 20px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           max-width: 600px;
           margin: 0 auto;
         }
@@ -437,12 +437,12 @@ export default function Home() {
         .demo-button {
           width: 100%;
           padding: 16px 24px;
-          border: 2px solid #0B57D0;
+          border: 2px solid var(--color-accent);
           border-radius: 4px;
-          background: #0B57D0;
+          background: var(--color-accent);
           color: white;
           cursor: pointer;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           font-weight: bold;
           text-align: center;
@@ -478,7 +478,7 @@ export default function Home() {
         }
 
         .divider span {
-          background: #FAFAF7;
+          background: var(--color-bg);
           padding: 0 20px;
           position: relative;
           color: #999;
@@ -492,7 +492,7 @@ export default function Home() {
           border-radius: 4px;
           background: transparent;
           cursor: pointer;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           text-align: center;
           color: #666;
@@ -512,7 +512,7 @@ export default function Home() {
           border: none;
           color: #666;
           cursor: pointer;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 14px;
           text-decoration: underline;
         }
@@ -563,7 +563,7 @@ export default function Home() {
           padding: 14px 12px;
           border: 1px solid #ccc;
           border-radius: 4px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           background: white;
           color: inherit;
@@ -573,7 +573,7 @@ export default function Home() {
 
         .username-input:focus {
           outline: none;
-          border-color: #0B57D0;
+          border-color: var(--color-accent);
           border-width: 2px;
           padding: 13px 11px;
           box-shadow: 0 0 0 2px rgba(11, 87, 208, 0.1);
@@ -583,7 +583,7 @@ export default function Home() {
         .url-preview input {
           border: none;
           padding: 12px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           background: transparent;
           flex: 1;
@@ -592,13 +592,13 @@ export default function Home() {
         }
 
         .create-button {
-          background: #111111 !important;
+          background: var(--color-text) !important;
           color: white !important;
           border: none !important;
           padding: 14px 32px;
           border-radius: 4px;
           cursor: pointer;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 18px;
           font-weight: bold;
           min-height: 48px;
@@ -625,7 +625,7 @@ export default function Home() {
           padding: 14px 12px;
           border: 1px solid #ccc;
           border-radius: 4px;
-          font-family: monospace;
+          font-family: var(--font-mono);
           font-size: 16px;
           background: white;
           color: inherit;
@@ -635,7 +635,7 @@ export default function Home() {
 
         input[type="password"]:focus {
           outline: none;
-          border-color: #0B57D0;
+          border-color: var(--color-accent);
           border-width: 2px;
           padding: 13px 11px;
           box-shadow: 0 0 0 2px rgba(11, 87, 208, 0.1);
@@ -699,7 +699,7 @@ export default function Home() {
           border-radius: 4px;
           background: white;
           cursor: pointer;
-          font-family: monospace;
+          font-family: var(--font-mono);
         }
 
         button:hover:not(:disabled) {
@@ -789,7 +789,7 @@ export default function Home() {
           }
 
           input[type="password"]:focus {
-            border-color: #8AB4F8;
+            border-color: var(--color-accent);
             border-width: 2px;
             padding: 13px 11px;
             box-shadow: 0 0 0 2px rgba(138, 180, 248, 0.1);
@@ -802,7 +802,7 @@ export default function Home() {
           }
 
           .username-input:focus {
-            border-color: #8AB4F8;
+            border-color: var(--color-accent);
             border-width: 2px;
             padding: 13px 11px;
             box-shadow: 0 0 0 2px rgba(138, 180, 248, 0.1);
@@ -849,7 +849,7 @@ export default function Home() {
         }
 
         .divider span {
-          background: #0B0B0C;
+          background: var(--color-bg);
         }
 
           .secondary-action {
@@ -873,9 +873,9 @@ export default function Home() {
         }
 
         .demo-button {
-          background: #8AB4F8;
-          border-color: #8AB4F8;
-          color: #0B0B0C;
+          background: var(--color-accent);
+          border-color: var(--color-accent);
+          color: var(--color-bg);
         }
 
         .demo-button:hover {


### PR DESCRIPTION
## Summary
- Defines `--color-bg`, `--color-text`, `--color-accent`, `--font-mono` in `styles/globals.css` with light/dark mode support
- Replaces all hardcoded hex values and `font-family: monospace` across 8 files in `pages/` and `components/`

## Test plan
- [ ] Visual check light + dark mode — colors unchanged
- [ ] CI passes