### PR TITLE
ux: warm microcopy — replace terminal tone with human-centric copy

### DIFF
--- a/__tests__/components/PasswordModal.test.js
+++ b/__tests__/components/PasswordModal.test.js
@@ -189,7 +189,7 @@ describe('PasswordModal', () => {
             />
         )
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
 
         // Focus the input and press Escape
         passwordInput.focus()

--- a/__tests__/components/PasswordModal.test.js
+++ b/__tests__/components/PasswordModal.test.js
@@ -26,15 +26,15 @@ describe('PasswordModal', () => {
             />
         )
 
-        expect(screen.queryByText('Enter Password')).not.toBeInTheDocument()
-        expect(screen.queryByPlaceholderText('Enter password to decrypt entries...')).not.toBeInTheDocument()
+        expect(screen.queryByText('Unlock your writing')).not.toBeInTheDocument()
+        expect(screen.queryByPlaceholderText('Your password')).not.toBeInTheDocument()
     })
 
     it('should render with default title when isOpen is true', () => {
         render(<PasswordModal {...defaultProps} />)
 
-        expect(screen.getByText('Enter Password')).toBeInTheDocument()
-        expect(screen.getByPlaceholderText('Enter password to decrypt entries...')).toBeInTheDocument()
+        expect(screen.getByText('Unlock your writing')).toBeInTheDocument()
+        expect(screen.getByPlaceholderText('Your password')).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Decrypt' })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument()
     })
@@ -54,7 +54,7 @@ describe('PasswordModal', () => {
     it('should focus the password input when modal opens', async () => {
         render(<PasswordModal {...defaultProps} />)
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
 
         await waitFor(() => {
             expect(passwordInput).toHaveFocus()
@@ -72,7 +72,7 @@ describe('PasswordModal', () => {
         const user = userEvent.setup()
         render(<PasswordModal {...defaultProps} />)
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
         const submitButton = screen.getByRole('button', { name: 'Decrypt' })
 
         expect(submitButton).toBeDisabled()
@@ -93,7 +93,7 @@ describe('PasswordModal', () => {
             />
         )
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
         const submitButton = screen.getByRole('button', { name: 'Decrypt' })
 
         await user.type(passwordInput, 'testpassword')
@@ -114,7 +114,7 @@ describe('PasswordModal', () => {
             />
         )
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
 
         await user.type(passwordInput, 'testpassword')
         await user.keyboard('{Enter}')
@@ -134,7 +134,7 @@ describe('PasswordModal', () => {
             />
         )
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
         const submitButton = screen.getByRole('button', { name: 'Decrypt' })
 
         await user.type(passwordInput, '   ')
@@ -203,7 +203,7 @@ describe('PasswordModal', () => {
 
         render(<PasswordModal {...defaultProps} />)
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
 
         await user.type(passwordInput, 'mypassword')
 
@@ -218,7 +218,7 @@ describe('PasswordModal', () => {
             />
         )
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
         fireEvent.change(passwordInput, { target: { value: 'testpassword' } })
 
         expect(passwordInput).toHaveValue('testpassword')
@@ -228,8 +228,8 @@ describe('PasswordModal', () => {
         rerender(<PasswordModal {...defaultProps} isOpen={true} />)
 
         // Component should reset internal state when reopened
-        const newPasswordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
-        // Note: This test verifies component behavior - in a real implementation, 
+        const newPasswordInput = screen.getByPlaceholderText('Your password')
+        // Note: This test verifies component behavior - in a real implementation,
         // the password state would need to be reset when modal opens
         expect(newPasswordInput).toHaveValue('testpassword') // Password persists without explicit reset
     })
@@ -237,7 +237,7 @@ describe('PasswordModal', () => {
     it('should have correct input type for password field', () => {
         render(<PasswordModal {...defaultProps} />)
 
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
         expect(passwordInput).toHaveAttribute('type', 'password')
     })
 
@@ -246,7 +246,7 @@ describe('PasswordModal', () => {
 
         // Form element exists but doesn't have role="form" by default
         const form = document.querySelector('form')
-        const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+        const passwordInput = screen.getByPlaceholderText('Your password')
         const submitButton = screen.getByRole('button', { name: 'Decrypt' })
         const cancelButton = screen.getByRole('button', { name: 'Cancel' })
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -23,10 +23,10 @@ describe('Home Page', () => {
 
   test('renders home page with title and form', () => {
     render(<Home />)
-    
+
     expect(screen.getByText('lekh.space/[username]')).toBeInTheDocument()
     expect(screen.getByPlaceholderText('[username]')).toBeInTheDocument()
-    expect(screen.getByText('[create →]')).toBeInTheDocument()
+    expect(screen.getByText('Create my space')).toBeInTheDocument()
   })
 
   test('updates username input when typing', async () => {
@@ -102,15 +102,15 @@ describe('Home Page', () => {
         eq: jest.fn(() => Promise.resolve({ data: [{ username: 'taken' }], error: null }))
       }))
     }))
-    
+
     const user = userEvent.setup()
     render(<Home />)
-    
+
     const input = screen.getByPlaceholderText('[username]')
     await user.type(input, 'taken')
-    
+
     await waitFor(() => {
-      const submitButton = screen.getByText('[create →]')
+      const submitButton = screen.getByText('Create my space')
       expect(submitButton).toBeDisabled()
     })
   })
@@ -129,23 +129,23 @@ describe('Home Page', () => {
       ok: true,
       json: jest.fn(() => Promise.resolve({ username: 'newuser' }))
     })
-    
+
     const user = userEvent.setup()
     render(<Home />)
-    
+
     const usernameInput = screen.getByPlaceholderText('[username]')
     await user.type(usernameInput, 'newuser')
-    
-    const passwordInput = screen.getByPlaceholderText('[••••••••]')
+
+    const passwordInput = screen.getByPlaceholderText('at least 8 characters')
     await user.type(passwordInput, 'SecurePassword123')
-    
+
     await waitFor(() => {
       expect(screen.getByText('available')).toBeInTheDocument()
     })
-    
-    const submitButton = screen.getByText('[create →]')
+
+    const submitButton = screen.getByText('Create my space')
     await user.click(submitButton)
-    
+
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith('/api/create-user', expect.objectContaining({
         method: 'POST'
@@ -177,23 +177,23 @@ describe('Home Page', () => {
       ok: false,
       json: jest.fn(() => Promise.resolve({ error: 'Database error' }))
     })
-    
+
     const user = userEvent.setup()
     render(<Home />)
-    
+
     const usernameInput = screen.getByPlaceholderText('[username]')
     await user.type(usernameInput, 'erroruser')
-    
-    const passwordInput = screen.getByPlaceholderText('[••••••••]')
+
+    const passwordInput = screen.getByPlaceholderText('at least 8 characters')
     await user.type(passwordInput, 'SecurePassword123')
-    
+
     await waitFor(() => {
       expect(screen.getByText('available')).toBeInTheDocument()
     })
-    
-    const submitButton = screen.getByText('[create →]')
+
+    const submitButton = screen.getByText('Create my space')
     await user.click(submitButton)
-    
+
     await waitFor(() => {
       expect(screen.getByText('Error: Unable to create your space. Please try again.')).toBeInTheDocument()
     })
@@ -215,14 +215,14 @@ describe('Home Page', () => {
     render(<Home />)
 
     // Should start with private flow
-    expect(screen.getByPlaceholderText('[••••••••]')).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('at least 8 characters')).toBeInTheDocument()
 
     // Click the secondary action to switch to public flow
     const publicButton = screen.getByText('Create a shared writing space →')
     await user.click(publicButton)
 
     // Password field should be hidden in public flow
-    expect(screen.queryByPlaceholderText('[••••••••]')).not.toBeInTheDocument()
+    expect(screen.queryByPlaceholderText('at least 8 characters')).not.toBeInTheDocument()
     expect(screen.getByText('Create a shared writing space')).toBeInTheDocument()
   })
 

--- a/__tests__/integration/e2e-encryption-flow.test.js
+++ b/__tests__/integration/e2e-encryption-flow.test.js
@@ -209,7 +209,7 @@ describe('End-to-End Encryption Flow', () => {
             )
 
             // User enters password
-            const passwordInput = screen.getByPlaceholderText('Enter password to decrypt entries...')
+            const passwordInput = screen.getByPlaceholderText('Your password')
             await user.type(passwordInput, password)
 
             // User submits

--- a/components/PasswordModal.js
+++ b/components/PasswordModal.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 
-export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Enter Password" }) {
+export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Unlock your writing" }) {
   const [password, setPassword] = useState('')
   const inputRef = useRef(null)
 
@@ -37,7 +37,7 @@ export default function PasswordModal({ isOpen, onSubmit, onClose, title = "Ente
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Enter password to decrypt entries..."
+            placeholder="Your password"
             className="password-input"
           />
           <div className="modal-buttons">

--- a/pages/[username]/all.js
+++ b/pages/[username]/all.js
@@ -212,7 +212,7 @@ export default function AllEntriesPage() {
             }
           }}>
             <div className="prompt-group">
-              <label>Password:</label>
+              <label>Your password</label>
               <input
                 type="password"
                 name="password"
@@ -225,7 +225,7 @@ export default function AllEntriesPage() {
               [Unlock →]
             </button>
           </form>
-          <p className="warning-text">⚠️ Forgot? Your entries are lost forever.</p>
+          <p className="warning-text">⚠️ There's no recovery if you forget this.</p>
         </div>
       ) : entries.length === 0 ? (
         <div className="no-entries">

--- a/pages/index.js
+++ b/pages/index.js
@@ -174,8 +174,8 @@ export default function Home() {
       {!showPublicFlow ? (
         <>
           <h1>lekh.space/[username]</h1>
-          <p>&gt; Your words, encrypted. Once saved, permanent.</p>
-          <p>&gt; Forget your password = lost forever.</p>
+          <p>Write freely. Everything is encrypted and stays private — only you can read it.</p>
+          <p>Your password is the key. Keep it safe — there's no recovery if you forget it.</p>
 
           <div className="demo-cta">
             <button
@@ -223,7 +223,7 @@ export default function Home() {
             </div>
 
             <div className="input-group">
-              <label>password:</label>
+              <label>Choose a password</label>
               <input
                 type="password"
                 value={password}
@@ -232,7 +232,7 @@ export default function Home() {
                   setAcknowledgedRisk(false) // Reset when password changes
                   if (message.startsWith('Error')) setMessage('')
                 }}
-                placeholder="[••••••••]"
+                placeholder="at least 8 characters"
                 required
               />
               {password && (
@@ -244,7 +244,7 @@ export default function Home() {
               )}
               {password && (
                 <div className="password-hint">
-                  No password reset. Forget it and your writing is gone.
+                  There's no recovery if you forget this. We can't reset it for you.
                 </div>
               )}
               {password && getPasswordStrength(password) === 'weak' && (
@@ -273,7 +273,7 @@ export default function Home() {
                 }
                 className="create-button"
               >
-                {isSubmitting ? 'creating...' : '[create →]'}
+                {isSubmitting ? 'Creating your space...' : 'Create my space'}
               </button>
             </div>
           </form>
@@ -353,7 +353,7 @@ export default function Home() {
 
             <div className="buttons">
               <button type="button" onClick={generateRandomUsername}>
-                Generate Random
+                Suggest a name
               </button>
               <button
                 type="submit"


### PR DESCRIPTION
## Summary

- Removed terminal-style `>` prompt prefixes from landing hero text
- Replaced bracket syntax (`[create →]`, `[••••••••]`) with plain language
- Reframed anxiety-inducing password warnings as responsibility, not threat
- Changed `Generate Random` → `Suggest a name`
- Updated `all.js` unlock flow to match consistent tone
- Updated all test assertions to match new copy

## Motivation

The critique identified a P1 tone mismatch: the sign-up flow read like a developer terminal (`>`, `[•••]`, equation syntax) while the brand intent is a warm, private notebook. First impressions were cold and technical.

## Test plan

- [ ] All existing tests pass with updated assertions
- [ ] Landing page hero copy reads warm and human
- [ ] Password creation flow has no anxiety-inducing language
- [ ] Unlock flow in `/[username]/all` matches consistent tone
- [ ] Shared space flow tone remains consistent